### PR TITLE
update to phpstan 1.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "phpstan/phpstan": "^1.0",
         "phpunit/phpunit": "^9.5",
         "symfony/var-dumper": "^5.3",
-        "thecodingmachine/phpstan-safe-rule": "^1.0"
+        "thecodingmachine/phpstan-safe-rule": "dev-patch-1"
     },
     "config": {
         "optimize-autoloader": true,
@@ -32,5 +32,11 @@
     "bin": [
         "bin/phpstan-baseline-analyze",
         "bin/phpstan-baseline-trend"
+    ],
+    "repositories": [
+        {
+            "type": "vcs",
+            "url": "https://github.com/staabm/phpstan-safe-rule"
+        }
     ]
 }

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "thecodingmachine/safe": "^1.3"
     },
     "require-dev": {
-        "phpstan/phpstan": "^0.12",
+        "phpstan/phpstan": "^1.0",
         "phpunit/phpunit": "^9.5",
         "symfony/var-dumper": "^5.3",
         "thecodingmachine/phpstan-safe-rule": "^1.0"


### PR DESCRIPTION
requires https://github.com/thecodingmachine/phpstan-safe-rule/pull/26 -> damit wir hier weiterkommen hab ich die composer.json erweitert, sodass **mein fork genutzt** wird, statt dem upstream (da es aktuell so aussieht als würde der PR nicht in naher zukunft gemergt werden wg. inaktivität)

relates to https://github.com/complex-gmbh/php-clx-symplify/pull/58