### PR TITLE
end2end test with symplify message format

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -42,5 +42,7 @@ jobs:
             -   name: Setup Problem Matchers for PHPUnit
                 run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
 
-            -   name: Run phpunit
+            -   run: composer require symplify/symplify
+
+            -   name: Run unit tests
                 run: vendor/bin/phpunit --colors=always

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -43,7 +43,6 @@ jobs:
                 run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
 
             -   run: composer require symplify/symplify
-                if: ${{ matrix.php-version != '7.4' }}
 
             -   name: Run unit tests
                 run: vendor/bin/phpunit --colors=always

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -42,7 +42,5 @@ jobs:
             -   name: Setup Problem Matchers for PHPUnit
                 run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
 
-            -   run: composer require symplify/symplify
-
             -   name: Run unit tests
                 run: vendor/bin/phpunit --colors=always

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -43,6 +43,7 @@ jobs:
                 run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
 
             -   run: composer require symplify/symplify
+                if: ${{ matrix.php-version != '7.4' }}
 
             -   name: Run unit tests
                 run: vendor/bin/phpunit --colors=always

--- a/composer.json
+++ b/composer.json
@@ -19,15 +19,19 @@
         "phpstan/phpstan": "^1.8",
         "phpunit/phpunit": "^9.5",
         "symfony/var-dumper": "^5.3",
+        "symplify/symplify": "^11.1",
         "thecodingmachine/phpstan-safe-rule": "^1.2"
     },
     "config": {
         "optimize-autoloader": true,
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {
+            "cweagans/composer-patches": false
+        }
     },
     "scripts": {
         "phpstan": "phpstan analyze",
-        "phpunit": "phpunit"
+        "test": "phpunit"
     },
     "bin": [
         "bin/phpstan-baseline-analyze",

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "phpstan/phpstan": "^1.8",
         "phpunit/phpunit": "^9.5",
         "symfony/var-dumper": "^5.3",
-        "symplify/symplify": "^11.0",
+        "symplify/symplify": "^10 || ^11.0",
         "thecodingmachine/phpstan-safe-rule": "^1.2"
     },
     "config": {

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "phpstan/phpstan": "^1.8",
         "phpunit/phpunit": "^9.5",
         "symfony/var-dumper": "^5.3",
-        "symplify/symplify": "^11.1",
+        "symplify/symplify": "^11.0",
         "thecodingmachine/phpstan-safe-rule": "^1.2"
     },
     "config": {

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "phpstan/phpstan": "^1.8",
         "phpunit/phpunit": "^9.5",
         "symfony/var-dumper": "^5.3",
-        "symplify/phpstan-rules": "^10 || ^11.0",
+        "symplify/phpstan-rules": "^11.0",
         "thecodingmachine/phpstan-safe-rule": "^1.2"
     },
     "config": {

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "phpstan/phpstan": "^1.8",
         "phpunit/phpunit": "^9.5",
         "symfony/var-dumper": "^5.3",
-        "symplify/symplify": "^10 || ^11.0",
+        "symplify/phpstan-rules": "^10 || ^11.0",
         "thecodingmachine/phpstan-safe-rule": "^1.2"
     },
     "config": {

--- a/lib/BaselineAnalyzer.php
+++ b/lib/BaselineAnalyzer.php
@@ -8,6 +8,11 @@ use function Safe\preg_match;
 final class BaselineAnalyzer
 {
     /**
+     * @var string
+     */
+    public const CLASS_COMPLEXITY_ERROR_MESSAGE = 'Class cognitive complexity is %d, keep it under %d';
+
+    /**
      * @var Baseline
      */
     private $baseline;
@@ -46,9 +51,10 @@ final class BaselineAnalyzer
 
     private function countClassesComplexity(BaselineError $baselineError): int
     {
-        return preg_match('/Class cognitive complexity is (?P<value>\d+), keep it under (?P<limit>\d+)/', $baselineError->message, $matches) === 1
-            ? (int)$matches['value'] * $baselineError->count
-            : 0;
+        if (sscanf($baselineError->unwrapMessage(), self::CLASS_COMPLEXITY_ERROR_MESSAGE, $value, $limit) > 0) {
+            return (int)$value * $baselineError->count;
+        }
+        return 0;
     }
 
     private function countInvalidPhpdocs(BaselineError $baselineError): int

--- a/lib/BaselineError.php
+++ b/lib/BaselineError.php
@@ -13,4 +13,14 @@ final class BaselineError
      * @var string
      */
     public $message;
+
+    /**
+     * Returns the baseline error message, without regex delimiters.
+     * Note: the message may still contain escaped regex meta characters.
+     * 
+     * @return string
+     */
+    public function unwrapMessage(): string {
+        return trim($this->message, '#^$');
+    }
 }

--- a/lib/BaselineError.php
+++ b/lib/BaselineError.php
@@ -17,7 +17,7 @@ final class BaselineError
     /**
      * Returns the baseline error message, without regex delimiters.
      * Note: the message may still contain escaped regex meta characters.
-     * 
+     *
      * @return string
      */
     public function unwrapMessage(): string {

--- a/tests/BaselineAnalyzerTest.php
+++ b/tests/BaselineAnalyzerTest.php
@@ -101,6 +101,10 @@ class BaselineAnalyzerTest extends TestCase
     }
 
     public function testSymplifyCompat() {
+        if (PHP_VERSION_ID < 80000) {
+            $this->markTestSkipped('symplify is only compatible with PHP 8');
+        }
+
         $this->assertSame(
             BaselineAnalyzer::CLASS_COMPLEXITY_ERROR_MESSAGE,
             ClassLikeCognitiveComplexityRule::ERROR_MESSAGE

--- a/tests/BaselineAnalyzerTest.php
+++ b/tests/BaselineAnalyzerTest.php
@@ -101,10 +101,6 @@ class BaselineAnalyzerTest extends TestCase
     }
 
     public function testSymplifyCompat() {
-        if (PHP_VERSION_ID < 80000) {
-            $this->markTestSkipped('symplify is only compatible with PHP 8');
-        }
-
         $this->assertSame(
             BaselineAnalyzer::CLASS_COMPLEXITY_ERROR_MESSAGE,
             ClassLikeCognitiveComplexityRule::ERROR_MESSAGE

--- a/tests/BaselineAnalyzerTest.php
+++ b/tests/BaselineAnalyzerTest.php
@@ -5,6 +5,7 @@ namespace staabm\PHPStanBaselineAnalysis\Tests;
 use PHPUnit\Framework\TestCase;
 use staabm\PHPStanBaselineAnalysis\Baseline;
 use staabm\PHPStanBaselineAnalysis\BaselineAnalyzer;
+use Symplify\PHPStanRules\CognitiveComplexity\Rules\ClassLikeCognitiveComplexityRule;
 
 class BaselineAnalyzerTest extends TestCase
 {
@@ -97,6 +98,13 @@ class BaselineAnalyzerTest extends TestCase
         $this->assertSame(0, $result->invalidPhpdocs);
         $this->assertSame(0, $result->unknownTypes);
         $this->assertSame(4, $result->anonymousVariables);
+    }
+
+    public function testSymplifyCompat() {
+        $this->assertSame(
+            BaselineAnalyzer::CLASS_COMPLEXITY_ERROR_MESSAGE,
+            ClassLikeCognitiveComplexityRule::ERROR_MESSAGE
+        );
     }
 
 }


### PR DESCRIPTION
adds a test case which fails in case symplify will adjust error messages and therefore our parsing would no longer work