### PR TITLE
DX: Add composer keywords

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ You need at least one of the supported PHPStan RuleSets/Rules configured in your
 ## Installation
 
 ```
-composer require staabm/phpstan-baseline-analysis
+composer require staabm/phpstan-baseline-analysis --dev
 ```
 
 ## Supported PHPStan RuleSets

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,7 @@
 {
     "name": "staabm/phpstan-baseline-analysis",
     "license": "MIT",
+    "keywords": ["dev", "phpstan", "phpstan-extension", "static analysis", "database access layer", "code quality"],
     "autoload": {
         "classmap": ["lib/"]
     },


### PR DESCRIPTION
as per https://github.com/composer/composer/pull/10960 this allows composer to warn the user, when installing the tool as a project dependency instead of a dev-dependency