### PR TITLE
add php baseline support

### DIFF
--- a/lib/Baseline.php
+++ b/lib/Baseline.php
@@ -24,8 +24,14 @@ final class Baseline {
      * @throws FilesystemException
      */
     static public function forFile(string $filePath):self {
-        $content = file_get_contents($filePath);
-        $decoded = Neon::decode($content);
+        $baselineExtension = pathinfo($filePath, PATHINFO_EXTENSION);
+
+        if ($baselineExtension === 'php') {
+            $decoded = require $filePath;
+        } else {
+            $content = file_get_contents($filePath);
+            $decoded = Neon::decode($content);
+        }
 
         if (!is_array($decoded)) {
             throw new RuntimeException(sprintf('expecting baseline %s to be non-empty', $filePath));

--- a/lib/BaselineFinder.php
+++ b/lib/BaselineFinder.php
@@ -21,7 +21,7 @@ final class BaselineFinder
                 continue;
             }
 
-            if (!str_ends_with($baseline, '.neon')) {
+            if (!str_ends_with($baseline, '.neon') && !str_ends_with($baseline, '.php')) {
                 continue;
             }
 

--- a/tests/BaselineAnalyzerTest.php
+++ b/tests/BaselineAnalyzerTest.php
@@ -3,6 +3,7 @@
 namespace staabm\PHPStanBaselineAnalysis\Tests;
 
 use PHPUnit\Framework\TestCase;
+use staabm\PHPStanBaselineAnalysis\AnalyzerResult;
 use staabm\PHPStanBaselineAnalysis\Baseline;
 use staabm\PHPStanBaselineAnalysis\BaselineAnalyzer;
 use TomasVotruba\CognitiveComplexity\Rules\ClassLikeCognitiveComplexityRule;
@@ -17,15 +18,15 @@ class BaselineAnalyzerTest extends TestCase
         $analyzer = new BaselineAnalyzer(Baseline::forFile(__DIR__ . '/fixtures/all-in.neon'));
         $result = $analyzer->analyze();
 
-        $this->assertSame(38, $result->overallErrors);
-        $this->assertSame(70, $result->classesComplexity);
-        $this->assertSame(2, $result->deprecations);
-        $this->assertSame(5, $result->invalidPhpdocs);
-        $this->assertSame(1, $result->unknownTypes);
-        $this->assertSame(4, $result->anonymousVariables);
-        $this->assertSame(1, $result->propertyTypeCoverage);
-        $this->assertSame(27, $result->paramTypeCoverage);
-        $this->assertSame(4, $result->returnTypeCoverage);
+        $this->allInAssertions($result);
+    }
+
+    function testAllInComplexityPhp():void
+    {
+        $analyzer = new BaselineAnalyzer(Baseline::forFile(__DIR__ . '/fixtures/all-in.php'));
+        $result = $analyzer->analyze();
+
+        $this->allInAssertions($result);
     }
 
     function testClassComplexity():void
@@ -157,6 +158,19 @@ class BaselineAnalyzerTest extends TestCase
             BaselineAnalyzer::RETURN_TYPE_DEClARATION_SEA_LEVEL_MESSAGE,
             ReturnTypeCoverageRule::ERROR_MESSAGE
         );
+    }
+
+    private function allInAssertions(AnalyzerResult $result): void
+    {
+        $this->assertSame(38, $result->overallErrors);
+        $this->assertSame(70, $result->classesComplexity);
+        $this->assertSame(2, $result->deprecations);
+        $this->assertSame(5, $result->invalidPhpdocs);
+        $this->assertSame(1, $result->unknownTypes);
+        $this->assertSame(4, $result->anonymousVariables);
+        $this->assertSame(1, $result->propertyTypeCoverage);
+        $this->assertSame(27, $result->paramTypeCoverage);
+        $this->assertSame(4, $result->returnTypeCoverage);
     }
 
 }

--- a/tests/fixtures/all-in.php
+++ b/tests/fixtures/all-in.php
@@ -1,0 +1,110 @@
+<?php declare(strict_types=1);
+
+$ignoreErrors = [];
+$ignoreErrors[] = [
+    'message' => '#^Access to an undefined property AccountController\\:\\:\\$anredekurz\\.$#',
+    'count' => 2,
+    'path' => '/controllers/AccountController.php',
+];
+$ignoreErrors[] = [
+    'message' => '#^Class cognitive complexity is 48, keep it under 30$#',
+    'count' => 1,
+    'path' => '/controllers/ApplicationController.php',
+];
+$ignoreErrors[] = [
+    'message' => '#^Cognitive complexity for "ApplicationController\\:\\:app_init\\(\\)" is 12, keep it under 10$#',
+    'count' => 1,
+    'path' => '/controllers/ApplicationController.php',
+];
+$ignoreErrors[] = [
+    'message' => '#^Cognitive complexity for "ApplicationController\\:\\:check_breadrumbs\\(\\)" is 16, keep it under 10$#',
+    'count' => 1,
+    'path' => '/controllers/ApplicationController.php',
+];
+$ignoreErrors[] = [
+    'message' => '#^Class cognitive complexity is 22, keep it under 30$#',
+    'count' => 1,
+    'path' => '/controllers/ApplicationController.php',
+];
+$ignoreErrors[] = [
+    'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
+    'count' => 10,
+    'path' => '/controllers/ApplicationController.php',
+];
+$ignoreErrors[] = [
+    'message' => '#^Cognitive complexity for "TablePdf\\:\\:NbLines\\(\\)" is 17, keep it under 10$#',
+    'count' => 1,
+    'path' => '/models/TablePdf.php',
+];
+$ignoreErrors[] = [
+    'message' => '#^Use explicit return value over magic &reference$#',
+    'count' => 1,
+    'path' => '/models/TablePdf.php',
+];
+$ignoreErrors[] = [
+    'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
+    'count' => 1,
+    'path' => '/models/Tarif.php',
+];
+$ignoreErrors[] = [
+    'message' => '#^Use explicit names over dynamic ones$#',
+    'count' => 1,
+    'path' => '/models/Zubehoer.php',
+];
+$ignoreErrors[] = [
+    'message' => '#^Access to an undefined property Zugabe\\:\\:\\$feat\\.$#',
+    'count' => 1,
+    'path' => '/models/Zugabe.php',
+];
+$ignoreErrors[] = [
+    'message' => '#^Access to an undefined property Zugabe\\:\\:\\$hersteller\\.$#',
+    'count' => 1,
+    'path' => '/models/Zugabe.php',
+];
+$ignoreErrors[] = [
+    'message' => '#^Use explicit names over dynamic ones$#',
+    'count' => 1,
+    'path' => '/models/Zugabe.php',
+];
+$ignoreErrors[] = [
+    'message' => '#^Instantiation of deprecated class Zend_Db_Expr\\.$#',
+    'count' => 2,
+    'path' => '/controllers/AccountWatchlistController.php',
+];
+$ignoreErrors[] = [
+    'message' => '#^PHPDoc tag @throws with type Throws is not subtype of Throwable$#',
+    'count' => 5,
+    'path' => '/lib/rest/RestClient.php',
+];
+$ignoreErrors[] = [
+    'message' => '#^Property ActionMailer\\:\\:\\$template_root has unknown class unknown_type as its type\\.$#',
+    'count' => 1,
+    'path' => '/lib/ActionMailer.php',
+];
+$ignoreErrors[] = [
+    'message' => '#^Anonymous variable in a `\\$lang\\-\\>\\.\\.\\.\\(\\)` method call can lead to false dead methods\\. Make sure the variable type is known$#',
+    'count' => 1,
+    'path' => '/application/Rocket/lib/Prospect/Service/ProspectDetailService.php',
+];
+$ignoreErrors[] = [
+    'message' => '#^Anonymous variables in a "\\$element\\-\\>value\\[0\\]\\-\\>\\.\\.\\." property fetch can lead to false dead property\\. Make sure the variable type is known$#',
+    'count' => 3,
+    'path' => '/application/Rocket/lib/bulkConsumerCheckout/integration/VatValidationClient.php',
+];
+$ignoreErrors[] = [
+    'message' => '#^Out of 1 possible property types, only 1 %% actually have it\\. Add more property types to get over 99 %%$#',
+    'count' => 1,
+    'path' => '/N/A',
+];
+$ignoreErrors[] = [
+    'message' => '#^Out of 22 possible return types, only 4 %% actually have it\\. Add more return types to get over 99 %%$#',
+    'count' => 1,
+    'path' => '/N/A',
+];
+$ignoreErrors[] = [
+    'message' => '#^Out of 33 possible param types, only 27 %% actually have it\\. Add more param types to get over 99 %%$#',
+    'count' => 1,
+    'path' => '/N/A',
+];
+
+return ['parameters' => ['ignoreErrors' => $ignoreErrors]];


### PR DESCRIPTION
This PR adds support for .php baseline files.

Let me know if it needs more tests.

Should be similar to how PHPStan does it.
https://github.com/phpstan/phpstan-src/blob/719831d8ea0838fd0ec9b5078bdbd95a575ec884/src/DependencyInjection/ContainerFactory.php#L284