### PR TITLE
Use setup-php tools in php-linter.yml

### DIFF
--- a/.github/workflows/php-linter.yml
+++ b/.github/workflows/php-linter.yml
@@ -22,9 +22,8 @@ jobs:
           uses: shivammathur/setup-php@v2
           with:
             php-version: 7.4
-            coverage: none # disable xdebug, pcov
-
-      -   run: composer require --dev php-parallel-lint/php-parallel-lint
+            coverage: none
+            tools: parallel-lint
 
       -   name: Lint PHP
-          run: vendor/bin/parallel-lint bin/ lib/ tests/
+          run: composer exec --no-interaction -- parallel-lint bin/ lib/ tests/


### PR DESCRIPTION
`setup-php` action can provide `parallel-lint`.

[_source_](https://github.com/szepeviktor/byte-level-care/blob/7826080b5acb14e4af493d938619539d91010221/.github/workflows/back-end.yml#L27-L33)
