### PR TITLE
Fix built

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "symfony/var-dumper": "^5.3",
         "thecodingmachine/phpstan-safe-rule": "^1.2",
         "tomasvotruba/cognitive-complexity": "^0.1.1",
-        "tomasvotruba/type-coverage": "^0.2.0",
+        "tomasvotruba/type-coverage": "^0.1.0",
         "tomasvotruba/unused-public": "^0.3.2"
     },
     "config": {


### PR DESCRIPTION
tomasvotruba/type-coverage 0.2.* changed the error format, therefore we fix to 0.1 for now to get a green build