### PR TITLE
Fix tomasvotruba/type-coverage 0.2.* test expectations

### DIFF
--- a/lib/BaselineAnalyzer.php
+++ b/lib/BaselineAnalyzer.php
@@ -164,6 +164,6 @@ final class BaselineAnalyzer
 
     private function normalizeMessage(BaselineError $baselineError): string {
         // makes the message format of tomasvotruba/type-coverage 0.2.* compatible with tomasvotruba/type-coverage 0.1.*
-        return preg_replace('/only \d+ \- (\d+).\d %/', 'only $1 %', $baselineError->unwrapMessage());
+        return \Safe\preg_replace('/only \d+ \- (\d+).\d %/', 'only $1 %', $baselineError->unwrapMessage());
     }
 }

--- a/lib/BaselineAnalyzer.php
+++ b/lib/BaselineAnalyzer.php
@@ -120,7 +120,7 @@ final class BaselineAnalyzer
     {
         if (
             sscanf(
-                $baselineError->unwrapMessage(),
+                $this->normalizeMessage($baselineError),
                 $this->printfToScanfFormat(self::PROPERTY_TYPE_DEClARATION_SEA_LEVEL_MESSAGE),
                 $absoluteCountMin, $coveragePercent, $goalPercent) >= 2
         ) {
@@ -132,7 +132,7 @@ final class BaselineAnalyzer
 
         if (
             sscanf(
-                $baselineError->unwrapMessage(),
+                $this->normalizeMessage($baselineError),
                 $this->printfToScanfFormat(self::PARAM_TYPE_DEClARATION_SEA_LEVEL_MESSAGE),
                 $absoluteCountMin, $coveragePercent, $goalPercent) >= 2
         ) {
@@ -144,7 +144,7 @@ final class BaselineAnalyzer
 
         if (
             sscanf(
-                $baselineError->unwrapMessage(),
+                $this->normalizeMessage($baselineError),
                 $this->printfToScanfFormat(self::RETURN_TYPE_DEClARATION_SEA_LEVEL_MESSAGE),
                 $absoluteCountMin, $coveragePercent, $goalPercent) >= 2
         ) {
@@ -159,6 +159,11 @@ final class BaselineAnalyzer
         // we don't need the float value, therefore simply ignore it, to make the format parseable by sscanf
         // see https://github.com/php/php-src/issues/12126
         // additionally this makes the output format of tomasvotruba/type-coverage 0.2.* compatible with tomasvotruba/type-coverage 0.1.*
-        return str_replace('%.1f', '', $format);
+        return str_replace('%d - %.1f', '%d', $format);
+    }
+
+    private function normalizeMessage(BaselineError $baselineError): string {
+        // makes the message format of tomasvotruba/type-coverage 0.2.* compatible with tomasvotruba/type-coverage 0.1.*
+        return preg_replace('/only \d+ \- (\d+).\d %/', 'only $1 %', $baselineError->unwrapMessage());
     }
 }

--- a/lib/BaselineError.php
+++ b/lib/BaselineError.php
@@ -22,7 +22,7 @@ final class BaselineError
      */
     public function unwrapMessage(): string {
         $msg = $this->message;
-        $msg = str_replace(['\\.', '%%'], ['.', '%'], $msg);
+        $msg = str_replace(['\\-', '\\.', '%%'], ['-', '.', '%'], $msg);
         $msg = trim($msg, '#^$');
         return $msg;
     }

--- a/tests/fixtures/sea-level-0_2.neon
+++ b/tests/fixtures/sea-level-0_2.neon
@@ -8,11 +8,11 @@ parameters:
 			path: N/A
 
 		-
-			message: "#^Out of 1000 possible return types, only 40 \\- 4\\.0 %% actually have it\\. Add more return types to get over 99 %%$#"
+			message: "#^Out of 1000 possible return types, only 41 \\- 4\\.1 %% actually have it\\. Add more return types to get over 99 %%$#"
 			count: 2
 			path: N/A
 
 		-
-			message: "#^Out of 1000 possible param types, only 270 \\- 27\\.0 %% actually have it\\. Add more param types to get over 99 %%$#"
+			message: "#^Out of 1000 possible param types, only 275 \\- 27\\.5 %% actually have it\\. Add more param types to get over 99 %%$#"
 			count: 2
 			path: N/A

--- a/tests/fixtures/sea-level-0_2.neon
+++ b/tests/fixtures/sea-level-0_2.neon
@@ -3,16 +3,16 @@
 parameters:
 	ignoreErrors:
 		-
-			message: "#^Out of 1 possible property types, only 1 \\- 36\\.0 %% actually have it\\. Add more property types to get over 99 %%$#"
+			message: "#^Out of 1000 possible property types, only 10 \\- 1\\.0 %% actually have it\\. Add more property types to get over 99 %%$#"
 			count: 2
 			path: N/A
 
 		-
-			message: "#^Out of 22 possible return types, only 4 \\- 36\\.0 %% actually have it\\. Add more return types to get over 99 %%$#"
+			message: "#^Out of 1000 possible return types, only 40 \\- 4\\.0 %% actually have it\\. Add more return types to get over 99 %%$#"
 			count: 2
 			path: N/A
 
 		-
-			message: "#^Out of 33 possible param types, only 27 \\- 36\\.0 %% actually have it\\. Add more param types to get over 99 %%$#"
+			message: "#^Out of 1000 possible param types, only 270 \\- 27\\.0 %% actually have it\\. Add more param types to get over 99 %%$#"
 			count: 2
 			path: N/A

--- a/tests/fixtures/sea-level.neon
+++ b/tests/fixtures/sea-level.neon
@@ -3,16 +3,16 @@
 parameters:
 	ignoreErrors:
 		-
-			message: "#^Out of 1 possible property types, only 1 %% actually have it\\. Add more property types to get over 99 %%$#"
+			message: "#^Out of 1000 possible property types, only 1 %% actually have it\\. Add more property types to get over 99 %%$#"
 			count: 1
 			path: N/A
 
 		-
-			message: "#^Out of 22 possible return types, only 4 %% actually have it\\. Add more return types to get over 99 %%$#"
+			message: "#^Out of 1000 possible return types, only 4 %% actually have it\\. Add more return types to get over 99 %%$#"
 			count: 1
 			path: N/A
 
 		-
-			message: "#^Out of 33 possible param types, only 27 %% actually have it\\. Add more param types to get over 99 %%$#"
+			message: "#^Out of 1000 possible param types, only 27 %% actually have it\\. Add more param types to get over 99 %%$#"
 			count: 1
 			path: N/A

--- a/tests/fixtures/sea-level.neon
+++ b/tests/fixtures/sea-level.neon
@@ -8,11 +8,11 @@ parameters:
 			path: N/A
 
 		-
-			message: "#^Out of 1000 possible return types, only 4 %% actually have it\\. Add more return types to get over 99 %%$#"
+			message: "#^Out of 500 possible return types, only 4 %% actually have it\\. Add more return types to get over 99 %%$#"
 			count: 1
 			path: N/A
 
 		-
-			message: "#^Out of 1000 possible param types, only 27 %% actually have it\\. Add more param types to get over 99 %%$#"
+			message: "#^Out of 100 possible param types, only 27 %% actually have it\\. Add more param types to get over 99 %%$#"
 			count: 1
 			path: N/A


### PR DESCRIPTION
Fixes

```
PHP Fatal error:  Uncaught LogicException: Invalid property coveragePercent: 1190 in /home/runner/.composer/vendor/staabm/phpstan-baseline-analysis/lib/BaselineAnalyzer.php:128
Stack trace:
#0 /home/runner/.composer/vendor/staabm/phpstan-baseline-analysis/lib/BaselineAnalyzer.php(60): staabm\PHPStanBaselineAnalysis\BaselineAnalyzer->checkSeaLevels()
#1 /home/runner/.composer/vendor/staabm/phpstan-baseline-analysis/lib/AnalyzeApplication.php(39): staabm\PHPStanBaselineAnalysis\BaselineAnalyzer->analyze()
#2 /home/runner/.composer/vendor/staabm/phpstan-baseline-analysis/bin/phpstan-baseline-analyze.php(41): staabm\PHPStanBaselineAnalysis\AnalyzeApplication->start()
#3 /home/runner/.composer/vendor/staabm/phpstan-baseline-analysis/bin/phpstan-baseline-analyze(15): require('...')
#4 /home/runner/.composer/vendor/bin/phpstan-baseline-analyze(119): include('...')
#5 {main}
  thrown in /home/runner/.composer/vendor/staabm/phpstan-baseline-analysis/lib/BaselineAnalyzer.php on line 128
```

----

see https://3v4l.org/KS6Ap