### PR TITLE
Added prefix for the output file

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,12 +84,12 @@ $ git clone ...
 $ phpstan-baseline-analyze *phpstan-baseline.neon --json > now.json
 
 $ git checkout `git rev-list -n 1 --before="1 week ago" HEAD`
-$ phpstan-baseline-analyze '*phpstan-baseline.neon' --json > 1-week-ago.json
+$ phpstan-baseline-analyze '*phpstan-baseline.neon' --json > phpstan-baseline-analyze-1-week-ago.json
 
 $ git checkout `git rev-list -n 1 --before="2 week ago" HEAD`
-$ phpstan-baseline-analyze '*phpstan-baseline.neon' --json > 2-weeks-ago.json
+$ phpstan-baseline-analyze '*phpstan-baseline.neon' --json > phpstan-baseline-analyze-2-weeks-ago.json
 
-$ php phpstan-baseline-graph '*.json' > result.html
+$ php phpstan-baseline-graph 'phpstan-baseline-analyze-*.json' > result.html
 ```
 
 ![PHPStan baseline analysis graph](https://github.com/staabm/phpstan-baseline-analysis/assets/120441/ea5abe25-21e8-43f2-9118-0967a75517c6)


### PR DESCRIPTION
Hi!

I've recently spend quite a long time trying to understand, why I'm getting error like this one below:
```
PHP Fatal error:  Uncaught RuntimeException: Expecting array, got string in /var/www/html/vendor/staabm/phpstan-baseline-analysis/lib/AnalyzerResultReader.php:23
```
after executing `php ./vendor/bin/phpstan-baseline-graph '*.json' > result.html` in my project.

The reason was really simple: `*.json` was catching all json files - including e. g. `composer.json`.